### PR TITLE
feat: Add "Share This Result" copy button

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next"
 import { Inter } from "next/font/google"
 import { Analytics } from "@vercel/analytics/next"
 import { ThemeProvider } from "@/components/theme-provider"
+import { Toaster } from "@/components/ui/toaster"
 import { Suspense } from "react"
 
 import "./globals.css"
@@ -32,6 +33,7 @@ export default function RootLayout({
             <div className="flex-1">
               {children}
             </div>
+            <Toaster />
           </ThemeProvider>
         </Suspense>
         <Analytics />

--- a/components/result-card.tsx
+++ b/components/result-card.tsx
@@ -3,9 +3,11 @@
 import { Card } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { TrendingUp, TrendingDown, CheckCircle, AlertTriangle } from "lucide-react"
+import { TrendingUp, TrendingDown, CheckCircle, AlertTriangle, Share } from "lucide-react"
 import { motion, AnimatePresence } from "framer-motion"
 import { calculateAttendance, type AttendanceData, type CalculationResult } from "@/lib/attendance-calculations"
+import { useToast } from "@/hooks/use-toast"
+import { generateShareText } from "@/util/clipboardTextGeneration"
 
 interface ResultCardProps {
   attendanceData: AttendanceData
@@ -13,6 +15,33 @@ interface ResultCardProps {
 
 export function ResultCard({ attendanceData }: ResultCardProps) {
   const result = calculateAttendance(attendanceData)
+  const { toast } = useToast()
+
+  const handleCopyResult = async () => {
+    if (!navigator.clipboard) {
+      toast({
+        title: "Copy failed",
+        description: "Clipboard not supported in this browser",
+        variant: "destructive"
+      })
+      return
+    }
+
+    try {
+      const shareText = generateShareText(result, attendanceData)
+      await navigator.clipboard.writeText(shareText)
+      toast({
+        title: "Result copied!",
+        description: "Attendance summary copied to clipboard",
+      })
+    } catch (error) {
+      toast({
+        title: "Copy failed",
+        description: "Failed to copy result to clipboard",
+        variant: "destructive"
+      })
+    }
+  }
 
   const getStatusIcon = () => {
     switch (result.status) {
@@ -47,6 +76,18 @@ export function ResultCard({ attendanceData }: ResultCardProps) {
     <Card className="p-6 rounded-2xl shadow-md hover:shadow-lg transition-all duration-200 hover:scale-[1.02] relative">
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-xl font-semibold text-foreground">Your Results</h2>
+        {result.status !== "awaiting" && (
+          <Button
+            onClick={handleCopyResult}
+            variant="outline"
+            size="sm"
+            className="flex items-center gap-2 hover:cursor-pointer hover: transition-colors"
+          >
+            <Share className="h-4 w-4" />
+            <span className="hidden sm:inline">Share Result</span>
+            <span className="sm:hidden">Share</span>
+          </Button>
+        )}
       </div>
 
       <div>

--- a/util/clipboardTextGeneration.ts
+++ b/util/clipboardTextGeneration.ts
@@ -1,0 +1,27 @@
+import { AttendanceData, CalculationResult } from "@/lib/attendance-calculations"
+
+export const generateShareText = (result: CalculationResult, attendanceData: AttendanceData) => {
+    const lines = [
+        "📊 Attendance Summary",
+        `- Current Attendance: ${result.currentAttendance.toFixed(1)}%`,
+        `- Attendance Criteria: ${attendanceData.attendanceCriteria}%`
+    ]
+
+    if (result.canBunk > 0) {
+        lines.push(`- You can bunk ${result.canBunk} more lecture${result.canBunk > 1 ? 's' : ''}.`)
+    }
+
+    if (result.mustAttend > 0) {
+        lines.push(`- You must attend ${result.mustAttend} more lecture${result.mustAttend > 1 ? 's' : ''} to reach ${attendanceData.attendanceCriteria}%.`)
+    }
+
+    if (result.status === "perfect") {
+        lines.push("- Status: Perfect Attendance 🎉")
+    } else if (result.canBunk === 0 && result.mustAttend === 0) {
+        lines.push("- Status: At Threshold ⚖️")
+    }
+
+    lines.push("", "Generated with BunkApp - Smart Attendance Calculator")
+
+    return lines.join("\n")
+}


### PR DESCRIPTION
Closes #4 

This pull request implements the "Share This Result" feature as described in the issue. It adds a button to the results panel that copies a formatted attendance summary to the user's clipboard, providing them with a simple way to share or save their calculation.

Changes Implemented:

- Added a "Copy Result" Button: A new button is now visible in the ResultCard component as soon as results are available.
- Clipboard Functionality: Implemented the navigator.clipboard.writeText() function to copy the results. It includes a fallback with an error message for browsers that don't support the Clipboard API.
- Structured Text Generation: Created a new utility, generateShareText, which takes the calculation result and produces a clean, human-readable text summary, exactly as specified in the issue's example output.
- User Feedback (Toasts): Integrated the Toaster component into the main layout. Users now receive a "Result copied!" toast for success or a descriptive error message if the copy action fails, ensuring clear visual feedback.
- Tested on Chrome and Firefox

Some Screenshots of the results:

 <img width="379" height="376" alt="Screenshot from 2025-10-02 19-43-50" src="https://github.com/user-attachments/assets/310b5b5d-4db7-40cc-8daf-744c720af282" />

 <img width="434" height="460" alt="Screenshot from 2025-10-02 19-39-26" src="https://github.com/user-attachments/assets/7af5f1cf-ba0a-4bf0-80f7-fc13c272c277" />

 <img width="382" height="77" alt="Screenshot from 2025-10-02 19-43-58" src="https://github.com/user-attachments/assets/ba01e979-af22-4e35-90b2-72f617a4245e" />
